### PR TITLE
Specify host address

### DIFF
--- a/app.py
+++ b/app.py
@@ -195,4 +195,4 @@ def get_api_data():
 
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
For some reason the API can't be accessed from outside without this